### PR TITLE
Port `ResNetV2Backbone`, `EfficientNetV2Backbone`, and `ImageClassifier` to Keras Core

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -83,8 +83,9 @@ jobs:
       run: |
         pytest keras_cv/models/backbones/resnet_v1 \
                keras_cv/models/backbones/resnet_v2 \
+               keras_cv/models/backbones/efficientnet_v2 \
                keras_cv/models/classification/image_classifier_test.py \
-               --durations 0
+               --durations 0 --run_large --run_extra_large
   format:
     name: Check the code format
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -81,7 +81,10 @@ jobs:
         KERAS_CV_MULTI_BACKEND: true
         KERAS_BACKEND: jax
       run: |
-        pytest keras_cv/models/backbones/resnet_v1 --durations 0
+        pytest keras_cv/models/backbones/resnet_v1 \
+               keras_cv/models/backbones/resnet_v2 \
+               keras_cv/models/classification/image_classifier_test.py \
+               --durations 0
   format:
     name: Check the code format
     runs-on: ubuntu-latest

--- a/keras_cv/backend/__init__.py
+++ b/keras_cv/backend/__init__.py
@@ -15,15 +15,34 @@ from keras_cv.backend.config import multi_backend
 
 if multi_backend():
     import keras_core as keras
+
+    if not hasattr(keras.utils, "register_keras_serializable"):
+        keras.utils.register_keras_serializable = (
+            keras.saving.register_keras_serializable
+        )
+    if not hasattr(keras.utils, "deserialize_keras_object"):
+        keras.utils.deserialize_keras_object = (
+            keras.saving.deserialize_keras_object
+        )
+    if not hasattr(keras.utils, "serialize_keras_object"):
+        keras.utils.serialize_keras_object = keras.saving.serialize_keras_object
+    if not hasattr(keras.utils, "get_file"):
+        keras.utils.get_file = keras.utils.file_utils.get_file
+    if not hasattr(keras.utils, "get_registered_object"):
+        keras.utils.get_registered_object = keras.saving.get_registered_object
+
+    if not hasattr(keras.layers, "serialize"):
+        keras.layers.serialize = keras.saving.serialize_keras_object
+    if not hasattr(keras.layers, "deserialize"):
+        keras.layers.deserialize = keras.saving.deserialize_keras_object
+
+    if not hasattr(keras.models, "load_model"):
+        keras.models.load_model = keras.saving.load_model
+
+    if not hasattr(keras.backend, "get_uid"):
+        keras.backend.get_uid = keras.utils.naming.get_uid
 else:
     from tensorflow import keras
-
-    if not hasattr(keras.saving, "deserialize_keras_object"):
-        keras.saving.deserialize_keras_object = (
-            keras.utils.deserialize_keras_object
-        )
-    if not hasattr(keras.saving, "serialize_keras_object"):
-        keras.saving.serialize_keras_object = keras.utils.serialize_keras_object
 
 
 from keras_cv.backend import ops

--- a/keras_cv/layers/fusedmbconv.py
+++ b/keras_cv/layers/fusedmbconv.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 
-from keras import backend
-from tensorflow import keras
-from tensorflow.keras import layers
+from keras_cv.backend import keras
 
 BN_AXIS = 3
 
@@ -30,7 +28,7 @@ CONV_KERNEL_INITIALIZER = {
 
 
 @keras.utils.register_keras_serializable(package="keras_cv")
-class FusedMBConvBlock(layers.Layer):
+class FusedMBConvBlock(keras.layers.Layer):
     """
     Implementation of the FusedMBConv block (Fused Mobile Inverted Residual
     Bottleneck) from:
@@ -112,7 +110,7 @@ class FusedMBConvBlock(layers.Layer):
         self.filters = self.input_filters * self.expand_ratio
         self.filters_se = max(1, int(input_filters * se_ratio))
 
-        self.conv1 = layers.Conv2D(
+        self.conv1 = keras.layers.Conv2D(
             filters=self.filters,
             kernel_size=kernel_size,
             strides=strides,
@@ -122,20 +120,20 @@ class FusedMBConvBlock(layers.Layer):
             use_bias=False,
             name=self.name + "expand_conv",
         )
-        self.bn1 = layers.BatchNormalization(
+        self.bn1 = keras.layers.BatchNormalization(
             axis=BN_AXIS,
             momentum=self.bn_momentum,
             name=self.name + "expand_bn",
         )
-        self.act = layers.Activation(
+        self.act = keras.layers.Activation(
             self.activation, name=self.name + "expand_activation"
         )
 
-        self.bn2 = layers.BatchNormalization(
+        self.bn2 = keras.layers.BatchNormalization(
             axis=BN_AXIS, momentum=self.bn_momentum, name=self.name + "bn"
         )
 
-        self.se_conv1 = layers.Conv2D(
+        self.se_conv1 = keras.layers.Conv2D(
             self.filters_se,
             1,
             padding="same",
@@ -144,7 +142,7 @@ class FusedMBConvBlock(layers.Layer):
             name=self.name + "se_reduce",
         )
 
-        self.se_conv2 = layers.Conv2D(
+        self.se_conv2 = keras.layers.Conv2D(
             self.filters,
             1,
             padding="same",
@@ -153,7 +151,7 @@ class FusedMBConvBlock(layers.Layer):
             name=self.name + "se_expand",
         )
 
-        self.output_conv = layers.Conv2D(
+        self.output_conv = keras.layers.Conv2D(
             filters=self.output_filters,
             kernel_size=1 if expand_ratio != 1 else kernel_size,
             strides=1,
@@ -164,7 +162,7 @@ class FusedMBConvBlock(layers.Layer):
             name=self.name + "project_conv",
         )
 
-        self.bn3 = layers.BatchNormalization(
+        self.bn3 = keras.layers.BatchNormalization(
             axis=BN_AXIS,
             momentum=self.bn_momentum,
             name=self.name + "project_bn",
@@ -172,7 +170,7 @@ class FusedMBConvBlock(layers.Layer):
 
     def build(self, input_shape):
         if self.name is None:
-            self.name = backend.get_uid("block0")
+            self.name = keras.backend.get_uid("block0")
 
     def call(self, inputs):
         # Expansion phase
@@ -185,18 +183,22 @@ class FusedMBConvBlock(layers.Layer):
 
         # Squeeze and excite
         if 0 < self.se_ratio <= 1:
-            se = layers.GlobalAveragePooling2D(name=self.name + "se_squeeze")(x)
+            se = keras.layers.GlobalAveragePooling2D(
+                name=self.name + "se_squeeze"
+            )(x)
             if BN_AXIS == 1:
                 se_shape = (self.filters, 1, 1)
             else:
                 se_shape = (1, 1, self.filters)
 
-            se = layers.Reshape(se_shape, name=self.name + "se_reshape")(se)
+            se = keras.layers.Reshape(se_shape, name=self.name + "se_reshape")(
+                se
+            )
 
             se = self.se_conv1(se)
             se = self.se_conv2(se)
 
-            x = layers.multiply([x, se], name=self.name + "se_excite")
+            x = keras.layers.multiply([x, se], name=self.name + "se_excite")
 
         # Output phase:
         x = self.output_conv(x)
@@ -207,12 +209,12 @@ class FusedMBConvBlock(layers.Layer):
         # Residual:
         if self.strides == 1 and self.input_filters == self.output_filters:
             if self.survival_probability:
-                x = layers.Dropout(
+                x = keras.layers.Dropout(
                     self.survival_probability,
                     noise_shape=(None, 1, 1, 1),
                     name=self.name + "drop",
                 )(x)
-            x = layers.add([x, inputs], name=self.name + "add")
+            x = keras.layers.add([x, inputs], name=self.name + "add")
         return x
 
     def get_config(self):

--- a/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone_presets_test.py
+++ b/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone_presets_test.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 
+import numpy as np
 import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 
+from keras_cv.backend import keras
 from keras_cv.models.backbones.efficientnet_v2.efficientnet_v2_aliases import (
     EfficientNetV2SBackbone,
 )
@@ -39,7 +41,7 @@ class EfficientNetV2PresetFullTest(tf.test.TestCase, parameterized.TestCase):
         *[(preset, preset) for preset in EfficientNetV2Backbone.presets]
     )
     def test_load_efficientnet(self, preset):
-        input_data = tf.ones(shape=(2, 224, 224, 3))
+        input_data = np.ones(shape=(2, 224, 224, 3))
         model = EfficientNetV2Backbone.from_preset(preset)
         model(input_data)
 
@@ -51,9 +53,9 @@ class EfficientNetV2PresetFullTest(tf.test.TestCase, parameterized.TestCase):
         levels = ["P3", "P4"]
         layer_names = [model.pyramid_level_inputs[level] for level in levels]
         backbone_model = get_feature_extractor(model, layer_names, levels)
-        inputs = tf.keras.Input(shape=[256, 256, 3])
+        inputs = keras.Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
         self.assertLen(outputs, 2)
         self.assertEquals(list(outputs.keys()), levels)
-        self.assertEquals(outputs["P3"].shape[:3], [None, 32, 32])
-        self.assertEquals(outputs["P4"].shape[:3], [None, 16, 16])
+        self.assertEquals(outputs["P3"].shape[:3], (None, 32, 32))
+        self.assertEquals(outputs["P4"].shape[:3], (None, 16, 16))

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
@@ -19,10 +19,7 @@ Reference:
 
 import copy
 
-from tensorflow import keras
-from tensorflow.keras import backend
-from tensorflow.keras import layers
-
+from keras_cv.backend import keras
 from keras_cv.models import utils
 from keras_cv.models.backbones.backbone import Backbone
 from keras_cv.models.backbones.resnet_v2.resnet_v2_backbone_presets import (
@@ -64,31 +61,31 @@ def apply_basic_block(
     """
 
     if name is None:
-        name = f"v2_basic_block_{backend.get_uid('v2_basic_block')}"
+        name = f"v2_basic_block_{keras.backend.get_uid('v2_basic_block')}"
 
-    use_preactivation = layers.BatchNormalization(
+    use_preactivation = keras.layers.BatchNormalization(
         axis=BN_AXIS, epsilon=BN_EPSILON, name=name + "_use_preactivation_bn"
     )(x)
 
-    use_preactivation = layers.Activation(
+    use_preactivation = keras.layers.Activation(
         "relu", name=name + "_use_preactivation_relu"
     )(use_preactivation)
 
     s = stride if dilation == 1 else 1
     if conv_shortcut:
-        shortcut = layers.Conv2D(filters, 1, strides=s, name=name + "_0_conv")(
-            use_preactivation
-        )
+        shortcut = keras.layers.Conv2D(
+            filters, 1, strides=s, name=name + "_0_conv"
+        )(use_preactivation)
     else:
         shortcut = (
-            layers.MaxPooling2D(
+            keras.layers.MaxPooling2D(
                 1, strides=stride, name=name + "_0_max_pooling"
             )(x)
             if s > 1
             else x
         )
 
-    x = layers.Conv2D(
+    x = keras.layers.Conv2D(
         filters,
         kernel_size,
         padding="SAME",
@@ -96,12 +93,12 @@ def apply_basic_block(
         use_bias=False,
         name=name + "_1_conv",
     )(use_preactivation)
-    x = layers.BatchNormalization(
+    x = keras.layers.BatchNormalization(
         axis=BN_AXIS, epsilon=BN_EPSILON, name=name + "_1_bn"
     )(x)
-    x = layers.Activation("relu", name=name + "_1_relu")(x)
+    x = keras.layers.Activation("relu", name=name + "_1_relu")(x)
 
-    x = layers.Conv2D(
+    x = keras.layers.Conv2D(
         filters,
         kernel_size,
         strides=s,
@@ -111,7 +108,7 @@ def apply_basic_block(
         name=name + "_2_conv",
     )(x)
 
-    x = layers.Add(name=name + "_out")([shortcut, x])
+    x = keras.layers.Add(name=name + "_out")([shortcut, x])
     return x
 
 
@@ -141,19 +138,19 @@ def apply_block(
       Output tensor for the residual block.
     """
     if name is None:
-        name = f"v2_block_{backend.get_uid('v2_block')}"
+        name = f"v2_block_{keras.backend.get_uid('v2_block')}"
 
-    use_preactivation = layers.BatchNormalization(
+    use_preactivation = keras.layers.BatchNormalization(
         axis=BN_AXIS, epsilon=BN_EPSILON, name=name + "_use_preactivation_bn"
     )(x)
 
-    use_preactivation = layers.Activation(
+    use_preactivation = keras.layers.Activation(
         "relu", name=name + "_use_preactivation_relu"
     )(use_preactivation)
 
     s = stride if dilation == 1 else 1
     if conv_shortcut:
-        shortcut = layers.Conv2D(
+        shortcut = keras.layers.Conv2D(
             4 * filters,
             1,
             strides=s,
@@ -161,22 +158,22 @@ def apply_block(
         )(use_preactivation)
     else:
         shortcut = (
-            layers.MaxPooling2D(
+            keras.layers.MaxPooling2D(
                 1, strides=stride, name=name + "_0_max_pooling"
             )(x)
             if s > 1
             else x
         )
 
-    x = layers.Conv2D(
+    x = keras.layers.Conv2D(
         filters, 1, strides=1, use_bias=False, name=name + "_1_conv"
     )(use_preactivation)
-    x = layers.BatchNormalization(
+    x = keras.layers.BatchNormalization(
         axis=BN_AXIS, epsilon=BN_EPSILON, name=name + "_1_bn"
     )(x)
-    x = layers.Activation("relu", name=name + "_1_relu")(x)
+    x = keras.layers.Activation("relu", name=name + "_1_relu")(x)
 
-    x = layers.Conv2D(
+    x = keras.layers.Conv2D(
         filters,
         kernel_size,
         strides=s,
@@ -185,13 +182,13 @@ def apply_block(
         dilation_rate=dilation,
         name=name + "_2_conv",
     )(x)
-    x = layers.BatchNormalization(
+    x = keras.layers.BatchNormalization(
         axis=BN_AXIS, epsilon=BN_EPSILON, name=name + "_2_bn"
     )(x)
-    x = layers.Activation("relu", name=name + "_2_relu")(x)
+    x = keras.layers.Activation("relu", name=name + "_2_relu")(x)
 
-    x = layers.Conv2D(4 * filters, 1, name=name + "_3_conv")(x)
-    x = layers.Add(name=name + "_out")([shortcut, x])
+    x = keras.layers.Conv2D(4 * filters, 1, name=name + "_3_conv")(x)
+    x = keras.layers.Add(name=name + "_out")([shortcut, x])
     return x
 
 
@@ -325,9 +322,9 @@ class ResNetV2Backbone(Backbone):
         x = inputs
 
         if include_rescaling:
-            x = layers.Rescaling(1 / 255.0)(x)
+            x = keras.layers.Rescaling(1 / 255.0)(x)
 
-        x = layers.Conv2D(
+        x = keras.layers.Conv2D(
             64,
             7,
             strides=2,
@@ -336,7 +333,7 @@ class ResNetV2Backbone(Backbone):
             name="conv1_conv",
         )(x)
 
-        x = layers.MaxPooling2D(
+        x = keras.layers.MaxPooling2D(
             3, strides=2, padding="same", name="pool1_pool"
         )(x)
 
@@ -356,12 +353,14 @@ class ResNetV2Backbone(Backbone):
                 first_shortcut=(block_type == "block" or stack_index > 0),
                 name=f"v2_stack_{stack_index}",
             )
-            pyramid_level_inputs[f"P{stack_index + 2}"] = x.node.layer.name
+            pyramid_level_inputs[
+                f"P{stack_index + 2}"
+            ] = utils.get_tensor_input_name(x)
 
-        x = layers.BatchNormalization(
+        x = keras.layers.BatchNormalization(
             axis=BN_AXIS, epsilon=BN_EPSILON, name="post_bn"
         )(x)
-        x = layers.Activation("relu", name="post_relu")(x)
+        x = keras.layers.Activation("relu", name="post_relu")(x)
 
         # Create model.
         super().__init__(inputs=inputs, outputs=x, **kwargs)

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_presets_test.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_presets_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for loading pretrained model presets."""
 
+import numpy as np
 import pytest
 import tensorflow as tf
 from absl.testing import parameterized
@@ -34,7 +35,7 @@ class ResNetV2PresetSmokeTest(tf.test.TestCase, parameterized.TestCase):
     """  # noqa: E501
 
     def setUp(self):
-        self.input_batch = tf.ones(shape=(8, 224, 224, 3))
+        self.input_batch = np.ones(shape=(8, 224, 224, 3))
 
     @parameterized.named_parameters(
         ("preset_with_weights", "resnet50_v2_imagenet"),
@@ -89,7 +90,7 @@ class ResNetV2PresetFullTest(tf.test.TestCase, parameterized.TestCase):
     """  # noqa: E501
 
     def test_load_resnetv2(self):
-        input_data = tf.ones(shape=(8, 224, 224, 3))
+        input_data = np.ones(shape=(8, 224, 224, 3))
         for preset in ResNetV2Backbone.presets:
             model = ResNetV2Backbone.from_preset(preset)
             model(input_data)

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
@@ -14,6 +14,7 @@
 
 import os
 
+import numpy as np
 import pytest
 import tensorflow as tf
 from absl.testing import parameterized
@@ -30,7 +31,7 @@ from keras_cv.utils.train import get_feature_extractor
 
 class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
-        self.input_batch = tf.ones(shape=(8, 224, 224, 3))
+        self.input_batch = np.ones(shape=(8, 224, 224, 3))
 
     def test_valid_call(self):
         model = ResNetV2Backbone(

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
@@ -55,12 +55,8 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         )
         model(self.input_batch)
 
-    @parameterized.named_parameters(
-        ("tf_format", "tf", "model"),
-        ("keras_format", "keras_v3", "model.keras"),
-    )
     @pytest.mark.large  # Saving is slow, so mark these large.
-    def test_saved_model(self, save_format, filename):
+    def test_saved_model(self):
         model = ResNetV2Backbone(
             stackwise_filters=[64, 128, 256, 512],
             stackwise_blocks=[2, 2, 2, 2],
@@ -68,8 +64,10 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
             include_rescaling=False,
         )
         model_output = model(self.input_batch)
-        save_path = os.path.join(self.get_temp_dir(), filename)
-        model.save(save_path, save_format=save_format)
+        save_path = os.path.join(
+            self.get_temp_dir(), "resnet_v2_backbone.keras"
+        )
+        model.save(save_path)
         restored_model = keras.models.load_model(save_path)
 
         # Check we got the real object back.
@@ -79,16 +77,14 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         restored_output = restored_model(self.input_batch)
         self.assertAllClose(model_output, restored_output)
 
-    @parameterized.named_parameters(
-        ("tf_format", "tf", "model"),
-        ("keras_format", "keras_v3", "model.keras"),
-    )
     @pytest.mark.large  # Saving is slow, so mark these large.
-    def test_saved_alias_model(self, save_format, filename):
+    def test_saved_alias_model(self):
         model = ResNet50V2Backbone()
         model_output = model(self.input_batch)
-        save_path = os.path.join(self.get_temp_dir(), filename)
-        model.save(save_path, save_format=save_format)
+        save_path = os.path.join(
+            self.get_temp_dir(), "resnet_v2_backbone.keras"
+        )
+        model.save(save_path)
         restored_model = keras.models.load_model(save_path)
 
         # Check we got the real object back.

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
@@ -114,10 +114,10 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         levels = ["P2", "P3", "P4", "P5"]
         self.assertLen(outputs, 4)
         self.assertEquals(list(outputs.keys()), levels)
-        self.assertEquals(outputs["P2"].shape, [None, 64, 64, 256])
-        self.assertEquals(outputs["P3"].shape, [None, 32, 32, 512])
-        self.assertEquals(outputs["P4"].shape, [None, 16, 16, 1024])
-        self.assertEquals(outputs["P5"].shape, [None, 8, 8, 2048])
+        self.assertEquals(outputs["P2"].shape, (None, 64, 64, 256))
+        self.assertEquals(outputs["P3"].shape, (None, 32, 32, 512))
+        self.assertEquals(outputs["P4"].shape, (None, 16, 16, 1024))
+        self.assertEquals(outputs["P5"].shape, (None, 8, 8, 2048))
 
     def test_create_backbone_model_with_level_config(self):
         model = ResNetV2Backbone(
@@ -134,8 +134,8 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         outputs = backbone_model(inputs)
         self.assertLen(outputs, 2)
         self.assertEquals(list(outputs.keys()), levels)
-        self.assertEquals(outputs["P3"].shape, [None, 32, 32, 512])
-        self.assertEquals(outputs["P4"].shape, [None, 16, 16, 1024])
+        self.assertEquals(outputs["P3"].shape, (None, 32, 32, 512))
+        self.assertEquals(outputs["P4"].shape, (None, 16, 16, 1024))
 
     @parameterized.named_parameters(
         ("one_channel", 1),

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
@@ -18,8 +18,8 @@ import numpy as np
 import pytest
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.models.backbones.resnet_v2.resnet_v2_backbone import (
     ResNet50V2Backbone,
 )

--- a/keras_cv/models/classification/image_classifier.py
+++ b/keras_cv/models/classification/image_classifier.py
@@ -15,9 +15,7 @@
 
 import copy
 
-from keras import layers
-from tensorflow import keras
-
+from keras_cv.backend import keras
 from keras_cv.models.backbones.backbone_presets import backbone_presets
 from keras_cv.models.backbones.backbone_presets import (
     backbone_presets_with_weights,
@@ -81,9 +79,9 @@ class ImageClassifier(Task):
         **kwargs,
     ):
         if pooling == "avg":
-            pooling_layer = layers.GlobalAveragePooling2D(name="avg_pool")
+            pooling_layer = keras.layers.GlobalAveragePooling2D(name="avg_pool")
         elif pooling == "max":
-            pooling_layer = layers.GlobalMaxPooling2D(name="max_pool")
+            pooling_layer = keras.layers.GlobalMaxPooling2D(name="max_pool")
         else:
             raise ValueError(
                 f'`pooling` must be one of "avg", "max". Received: {pooling}.'
@@ -91,7 +89,7 @@ class ImageClassifier(Task):
         inputs = backbone.input
         x = backbone(inputs)
         x = pooling_layer(x)
-        outputs = layers.Dense(
+        outputs = keras.layers.Dense(
             num_classes,
             activation=activation,
             name="predictions",

--- a/keras_cv/models/classification/image_classifier_test.py
+++ b/keras_cv/models/classification/image_classifier_test.py
@@ -20,8 +20,8 @@ import numpy as np
 import pytest
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.models.backbones.resnet_v2.resnet_v2_backbone import (
     ResNet18V2Backbone,
 )

--- a/keras_cv/models/classification/image_classifier_test.py
+++ b/keras_cv/models/classification/image_classifier_test.py
@@ -78,19 +78,15 @@ class ImageClassifierTest(tf.test.TestCase, parameterized.TestCase):
                 pooling="clowntown",
             )
 
-    @parameterized.named_parameters(
-        ("tf_format", "tf", "model"),
-        ("keras_format", "keras_v3", "model.keras"),
-    )
     @pytest.mark.large  # Saving is slow, so mark these large.
-    def test_saved_model(self, save_format, filename):
+    def test_saved_model(self):
         model = ImageClassifier(
             backbone=ResNet18V2Backbone(),
             num_classes=2,
         )
         model_output = model(self.input_batch)
-        save_path = os.path.join(self.get_temp_dir(), filename)
-        model.save(save_path, save_format=save_format)
+        save_path = os.path.join(self.get_temp_dir(), "image_classifier.keras")
+        model.save(save_path)
         restored_model = keras.models.load_model(save_path)
 
         # Check we got the real object back.

--- a/keras_cv/models/classification/image_classifier_test.py
+++ b/keras_cv/models/classification/image_classifier_test.py
@@ -16,6 +16,7 @@
 
 import os
 
+import numpy as np
 import pytest
 import tensorflow as tf
 from absl.testing import parameterized
@@ -29,7 +30,7 @@ from keras_cv.models.classification.image_classifier import ImageClassifier
 
 class ImageClassifierTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
-        self.input_batch = tf.ones(shape=(2, 224, 224, 3))
+        self.input_batch = np.ones(shape=(2, 224, 224, 3))
         self.dataset = tf.data.Dataset.from_tensor_slices(
             (self.input_batch, tf.one_hot(tf.ones((2,), dtype="int32"), 2))
         ).batch(4)
@@ -109,7 +110,7 @@ class ImageClassifierPresetSmokeTest(tf.test.TestCase, parameterized.TestCase):
     """
 
     def setUp(self):
-        self.input_batch = tf.ones(shape=(2, 224, 224, 3))
+        self.input_batch = np.ones(shape=(2, 224, 224, 3))
 
     @parameterized.named_parameters(
         (

--- a/keras_cv/models/task.py
+++ b/keras_cv/models/task.py
@@ -15,8 +15,7 @@
 
 import os
 
-from tensorflow import keras
-
+from keras_cv.backend import keras
 from keras_cv.utils.python_utils import classproperty
 from keras_cv.utils.python_utils import format_docstring
 


### PR DESCRIPTION
This PR ports `ResNetV2Backbone`, `EfficientNetV2Backbone`, and `ImageClassifier` to Keras Core.

A small change to the backend code: Instead of aliasing attributes/functions within `keras`, I think we should alias within `keras_core`. This way we can minimize the diffs porting components from `keras` to `keras_core`. Thanks for coming up with this backend @ianstenbit! This made it really easy to port!