### PR TITLE
Core kpls

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -79,6 +79,7 @@ jobs:
         KERAS_BACKEND: jax
       run: |
         pytest keras_cv/bounding_box \
+               keras_cv/callbacks \
                keras_cv/layers/object_detection \
                keras_cv/layers/preprocessing \
                keras_cv/losses \

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -80,11 +80,12 @@ jobs:
       run: |
         pytest keras_cv/bounding_box \
                keras_cv/layers/object_detection \
+               keras_cv/layers/preprocessing \
                keras_cv/losses \
                keras_cv/models/backbones \
                keras_cv/models/classification/image_classifier_test.py \
                keras_cv/models/object_detection/retinanet \
-               --durations 0 --run_large
+               --durations 0
   format:
     name: Check the code format
     runs-on: ubuntu-latest

--- a/keras_cv/backend/__init__.py
+++ b/keras_cv/backend/__init__.py
@@ -65,6 +65,7 @@ else:
     keras.activations.silu = keras.activations.swish
 
 from keras_cv.backend import ops  # noqa: E402
+from keras_cv.backend import tf_ops  # noqa: E402
 
 
 def supports_ragged():

--- a/keras_cv/backend/ops.py
+++ b/keras_cv/backend/ops.py
@@ -16,16 +16,6 @@ from keras_cv.backend.config import multi_backend
 if multi_backend():
     from keras_core.backend import vectorized_map  # noqa: F403, F401
     from keras_core.operations import *  # noqa: F403, F401
+    from keras_core.utils.image_utils import smart_resize  # noqa: F403, F401
 else:
-    from keras_core.backend.tensorflow import *  # noqa: F403, F401
-    from keras_core.backend.tensorflow.core import *  # noqa: F403, F401
-    from keras_core.backend.tensorflow.math import *  # noqa: F403, F401
-    from keras_core.backend.tensorflow.nn import *  # noqa: F403, F401
-    from keras_core.backend.tensorflow.numpy import *  # noqa: F403, F401
-
-    # Some TF APIs where the numpy API doesn't support raggeds that we need
-    from tensorflow import concat as concatenate  # noqa: F403, F401
-    from tensorflow import range as arange  # noqa: F403, F401
-    from tensorflow import reduce_max as max  # noqa: F403, F401
-    from tensorflow import reshape  # noqa: F403, F401
-    from tensorflow import split  # noqa: F403, F401
+    from keras_cv.backend.tf_ops import *  # noqa: F403, F401

--- a/keras_cv/backend/ops.py
+++ b/keras_cv/backend/ops.py
@@ -14,6 +14,7 @@
 from keras_cv.backend.config import multi_backend
 
 if multi_backend():
+    from keras_core.backend import convert_to_numpy  # noqa: F403, F401
     from keras_core.backend import vectorized_map  # noqa: F403, F401
     from keras_core.operations import *  # noqa: F403, F401
     from keras_core.utils.image_utils import smart_resize  # noqa: F403, F401

--- a/keras_cv/backend/scope.py
+++ b/keras_cv/backend/scope.py
@@ -1,0 +1,34 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import copy
+
+from keras_cv import backend
+from keras_cv.backend import ops
+from keras_cv.backend import tf_ops
+
+_ORIGINAL_OPS = copy.copy(backend.ops.__dict__)
+_ORIGINAL_SUPPORTS_RAGGED = backend.supports_ragged
+
+
+class TFDataScope:
+    def __enter__(self):
+        for k, v in ops.__dict__.items():
+            if k in tf_ops.__dict__:
+                setattr(ops, k, getattr(tf_ops, k))
+        backend.supports_ragged = lambda: True
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        for k, v in ops.__dict__.items():
+            setattr(ops, k, _ORIGINAL_OPS[k])
+        backend.supports_ragged = _ORIGINAL_SUPPORTS_RAGGED

--- a/keras_cv/backend/tf_ops.py
+++ b/keras_cv/backend/tf_ops.py
@@ -1,0 +1,15 @@
+from keras_core.backend.tensorflow import *  # noqa: F403, F401
+from keras_core.backend.tensorflow.core import *  # noqa: F403, F401
+from keras_core.backend.tensorflow.math import *  # noqa: F403, F401
+from keras_core.backend.tensorflow.nn import *  # noqa: F403, F401
+from keras_core.backend.tensorflow.numpy import *  # noqa: F403, F401
+
+# Some TF APIs where the numpy API doesn't support raggeds that we need
+from tensorflow import concat as concatenate  # noqa: F403, F401
+from tensorflow import range as arange  # noqa: F403, F401
+from tensorflow import reduce_max as max  # noqa: F403, F401
+from tensorflow import reshape  # noqa: F403, F401
+from tensorflow import split  # noqa: F403, F401
+from tensorflow.keras.preprocessing.image import (  # noqa: F403, F401
+    smart_resize,
+)

--- a/keras_cv/backend/tf_ops.py
+++ b/keras_cv/backend/tf_ops.py
@@ -23,4 +23,6 @@ from tensorflow import range as arange  # noqa: F403, F401
 from tensorflow import reduce_max as max  # noqa: F403, F401
 from tensorflow import reshape  # noqa: F403, F401
 from tensorflow import split  # noqa: F403, F401
-from tensorflow.keras.preprocessing.image import smart_resize  # noqa: F403, F401
+from tensorflow.keras.preprocessing.image import (  # noqa: F403, F401
+    smart_resize,
+)

--- a/keras_cv/backend/tf_ops.py
+++ b/keras_cv/backend/tf_ops.py
@@ -1,3 +1,16 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from keras_core.backend.tensorflow import *  # noqa: F403, F401
 from keras_core.backend.tensorflow.core import *  # noqa: F403, F401
 from keras_core.backend.tensorflow.math import *  # noqa: F403, F401
@@ -10,6 +23,4 @@ from tensorflow import range as arange  # noqa: F403, F401
 from tensorflow import reduce_max as max  # noqa: F403, F401
 from tensorflow import reshape  # noqa: F403, F401
 from tensorflow import split  # noqa: F403, F401
-from tensorflow.keras.preprocessing.image import (  # noqa: F403, F401
-    smart_resize,
-)
+from tensorflow.keras.preprocessing.image import smart_resize  # noqa: F403, F401

--- a/keras_cv/backend/tf_ops.py
+++ b/keras_cv/backend/tf_ops.py
@@ -27,4 +27,4 @@ from tensorflow.keras.preprocessing.image import (  # noqa: F403, F401
     smart_resize,
 )
 
-convert_to_numpy = lambda x: x.numpy() if is_tensor(x) else x
+convert_to_numpy = lambda x: x.numpy() if is_tensor(x) else x  # noqa: F405

--- a/keras_cv/backend/tf_ops.py
+++ b/keras_cv/backend/tf_ops.py
@@ -26,3 +26,5 @@ from tensorflow import split  # noqa: F403, F401
 from tensorflow.keras.preprocessing.image import (  # noqa: F403, F401
     smart_resize,
 )
+
+convert_to_numpy = lambda x: x.numpy() if is_tensor(x) else x

--- a/keras_cv/bounding_box/converters_test.py
+++ b/keras_cv/bounding_box/converters_test.py
@@ -19,8 +19,8 @@ import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 
+from keras_cv import backend
 from keras_cv import bounding_box
-from keras_cv.backend import supports_ragged
 
 xyxy_box = np.array([[[10, 20, 110, 120], [20, 30, 120, 130]]], dtype="float32")
 yxyx_box = np.array([[[20, 10, 120, 110], [30, 20, 130, 120]]], dtype="float32")
@@ -104,7 +104,7 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
 
     @parameterized.named_parameters(*test_image_ragged)
     @pytest.mark.skipif(
-        supports_ragged() is False,
+        backend.supports_ragged() is False,
         reason="Only TensorFlow supports raggeds",
     )
     def test_converters_ragged_images(self, source, target):
@@ -158,7 +158,7 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
 
     @parameterized.named_parameters(*test_cases)
     @pytest.mark.skipif(
-        supports_ragged() is False,
+        backend.supports_ragged() is False,
         reason="Only TensorFlow supports raggeds",
     )
     def test_ragged_bounding_box(self, source, target):
@@ -173,7 +173,7 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
 
     @parameterized.named_parameters(*test_image_ragged)
     @pytest.mark.skipif(
-        supports_ragged() is False,
+        backend.supports_ragged() is False,
         reason="Only TensorFlow supports raggeds",
     )
     def test_ragged_bounding_box_ragged_images(self, source, target):
@@ -188,7 +188,7 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
 
     @parameterized.named_parameters(*test_cases)
     @pytest.mark.skipif(
-        supports_ragged() is False,
+        backend.supports_ragged() is False,
         reason="Only TensorFlow supports raggeds",
     )
     def test_ragged_bounding_box_with_image_shape(self, source, target):
@@ -206,7 +206,7 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
 
     @parameterized.named_parameters(*test_image_ragged)
     @pytest.mark.skipif(
-        supports_ragged() is False,
+        backend.supports_ragged() is False,
         reason="Only TensorFlow supports raggeds",
     )
     def test_dense_bounding_box_with_ragged_images(self, source, target):

--- a/keras_cv/bounding_box/mask_invalid_detections.py
+++ b/keras_cv/bounding_box/mask_invalid_detections.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from keras_cv import backend
 from keras_cv.backend import ops
-from keras_cv.backend import supports_ragged
 from keras_cv.bounding_box.to_ragged import to_ragged
 from keras_cv.bounding_box.validate_format import validate_format
 
@@ -87,7 +87,7 @@ def mask_invalid_detections(bounding_boxes, output_ragged=False):
     if confidence is not None:
         result["confidence"] = confidence
 
-    if output_ragged and supports_ragged():
+    if output_ragged and backend.supports_ragged():
         return to_ragged(result)
 
     return result

--- a/keras_cv/bounding_box/mask_invalid_detections_test.py
+++ b/keras_cv/bounding_box/mask_invalid_detections_test.py
@@ -16,8 +16,8 @@ import numpy as np
 import pytest
 import tensorflow as tf
 
+from keras_cv import backend
 from keras_cv import bounding_box
-from keras_cv.backend import supports_ragged
 
 
 class MaskInvalidDetectionsTest(tf.test.TestCase):
@@ -44,7 +44,7 @@ class MaskInvalidDetectionsTest(tf.test.TestCase):
         )
 
     @pytest.mark.skipif(
-        supports_ragged() is False,
+        backend.supports_ragged() is False,
         reason="Only TensorFlow supports raggeds",
     )
     def test_ragged_outputs(self):
@@ -69,7 +69,7 @@ class MaskInvalidDetectionsTest(tf.test.TestCase):
         self.assertEqual(result["boxes"][1].shape[0], 3)
 
     @pytest.mark.skipif(
-        supports_ragged() is False,
+        backend.supports_ragged() is False,
         reason="Only TensorFlow supports raggeds",
     )
     def test_correctly_masks_confidence(self):

--- a/keras_cv/bounding_box/to_dense_test.py
+++ b/keras_cv/bounding_box/to_dense_test.py
@@ -14,13 +14,13 @@
 import pytest
 import tensorflow as tf
 
+from keras_cv import backend
 from keras_cv import bounding_box
-from keras_cv.backend import supports_ragged
 
 
 class ToDenseTest(tf.test.TestCase):
     @pytest.mark.skipif(
-        supports_ragged() is False,
+        backend.supports_ragged() is False,
         reason="Only TensorFlow supports raggeds",
     )
     def test_converts_to_dense(self):

--- a/keras_cv/bounding_box/to_ragged.py
+++ b/keras_cv/bounding_box/to_ragged.py
@@ -14,7 +14,7 @@
 import tensorflow as tf
 
 import keras_cv.bounding_box.validate_format as validate_format
-from keras_cv.backend import supports_ragged
+from keras_cv import backend
 
 
 def to_ragged(bounding_boxes, sentinel=-1, dtype=tf.float32):
@@ -50,7 +50,7 @@ def to_ragged(bounding_boxes, sentinel=-1, dtype=tf.float32):
         dictionary of `tf.RaggedTensor` or 'tf.Tensor' containing the filtered
         bounding boxes.
     """
-    if supports_ragged() is False:
+    if backend.supports_ragged() is False:
         raise NotImplementedError(
             "`bounding_box.to_ragged` was called using a backend which does "
             "not support ragged tensors."

--- a/keras_cv/bounding_box/to_ragged_test.py
+++ b/keras_cv/bounding_box/to_ragged_test.py
@@ -15,13 +15,13 @@ import numpy as np
 import pytest
 import tensorflow as tf
 
+from keras_cv import backend
 from keras_cv import bounding_box
-from keras_cv.backend import supports_ragged
 
 
 class ToRaggedTest(tf.test.TestCase):
     @pytest.mark.skipif(
-        supports_ragged() is False,
+        backend.supports_ragged() is False,
         reason="Only TensorFlow supports raggeds",
     )
     def test_converts_to_ragged(self):
@@ -53,7 +53,7 @@ class ToRaggedTest(tf.test.TestCase):
         )
 
     @pytest.mark.skipif(
-        supports_ragged() is False,
+        backend.supports_ragged() is False,
         reason="Only TensorFlow supports raggeds",
     )
     def test_round_trip(self):
@@ -83,7 +83,7 @@ class ToRaggedTest(tf.test.TestCase):
         )
 
     @pytest.mark.skipif(
-        supports_ragged() is True,
+        backend.supports_ragged() is True,
         reason="Only applies to backends which don't support raggeds",
     )
     def test_backend_without_raggeds_throws(self):

--- a/keras_cv/callbacks/pycoco_callback.py
+++ b/keras_cv/callbacks/pycoco_callback.py
@@ -11,10 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import numpy as np
 import tensorflow as tf
 from keras.callbacks import Callback
 
 from keras_cv import bounding_box
+from keras_cv.backend import ops
 from keras_cv.metrics.coco import compute_pycoco_metrics
 from keras_cv.models.object_detection.__internal__ import unpack_input
 from keras_cv.utils.conditional_imports import assert_pycocotools_installed
@@ -54,28 +56,37 @@ class PyCOCOCallback(Callback):
     def on_epoch_end(self, epoch, logs=None):
         logs = logs or {}
 
-        def images_only(data):
-            images, boxes = unpack_input(data)
+        def images_only(data, maybe_boxes=None):
+            if maybe_boxes is None:
+                images, boxes = unpack_input(data)
+            else:
+                images = data
+                boxes = maybe_boxes
             return images
 
-        def boxes_only(data):
-            images, boxes = unpack_input(data)
-            return bounding_box.to_ragged(boxes)
+        def boxes_only(data, maybe_boxes=None):
+            if maybe_boxes is None:
+                images, boxes = unpack_input(data)
+            else:
+                images = data
+                boxes = maybe_boxes
+            return boxes
 
         images_only_ds = self.val_data.map(images_only)
         y_pred = self.model.predict(images_only_ds)
         box_pred = y_pred["boxes"]
-        cls_pred = y_pred["classes"]
-        confidence_pred = y_pred["confidence"]
-        valid_det = y_pred["num_detections"]
+        cls_pred = ops.convert_to_numpy(y_pred["classes"])
+        confidence_pred = ops.convert_to_numpy(y_pred["confidence"])
+        valid_det = ops.convert_to_numpy(y_pred["num_detections"])
 
         gt = [boxes for boxes in self.val_data.map(boxes_only)]
-        gt_boxes = tf.concat(
-            [boxes["boxes"] for boxes in gt],
+        print(gt)
+        gt_boxes = ops.concatenate(
+            [ops.convert_to_numpy(boxes["boxes"]) for boxes in gt],
             axis=0,
         )
-        gt_classes = tf.concat(
-            [boxes["classes"] for boxes in gt],
+        gt_classes = ops.concatenate(
+            [ops.convert_to_numpy(boxes["classes"]) for boxes in gt],
             axis=0,
         )
 
@@ -88,17 +99,26 @@ class PyCOCOCallback(Callback):
             gt_boxes, source=self.bounding_box_format, target="yxyx"
         )
 
-        source_ids = tf.strings.as_string(
-            tf.linspace(1, total_images, total_images), precision=0
+        source_ids = np.char.mod(
+            "%d", np.linspace(1, total_images, total_images)
         )
+        num_detections = ops.sum(ops.cast(gt_classes > 0, "int32"), axis=-1)
 
         ground_truth = {
             "source_id": [source_ids],
-            "height": [tf.tile(tf.constant([height]), [total_images])],
-            "width": [tf.tile(tf.constant([width]), [total_images])],
-            "num_detections": [gt_boxes.row_lengths(axis=1)],
-            "boxes": [gt_boxes.to_tensor(-1)],
-            "classes": [gt_classes.to_tensor(-1)],
+            "height": [
+                ops.convert_to_numpy(
+                    ops.tile(ops.array([height]), [total_images])
+                )
+            ],
+            "width": [
+                ops.convert_to_numpy(
+                    ops.tile(ops.array([width]), [total_images])
+                )
+            ],
+            "num_detections": [ops.convert_to_numpy(num_detections)],
+            "boxes": [ops.convert_to_numpy(gt_boxes)],
+            "classes": [ops.convert_to_numpy(gt_classes)],
         }
 
         box_pred = bounding_box.convert_format(
@@ -107,7 +127,7 @@ class PyCOCOCallback(Callback):
 
         predictions = {
             "source_id": [source_ids],
-            "detection_boxes": [box_pred],
+            "detection_boxes": [ops.convert_to_numpy(box_pred)],
             "detection_classes": [cls_pred],
             "detection_scores": [confidence_pred],
             "num_detections": [valid_det],

--- a/keras_cv/callbacks/pycoco_callback.py
+++ b/keras_cv/callbacks/pycoco_callback.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import numpy as np
-import tensorflow as tf
 from keras.callbacks import Callback
 
 from keras_cv import bounding_box
@@ -61,14 +60,12 @@ class PyCOCOCallback(Callback):
                 images, boxes = unpack_input(data)
             else:
                 images = data
-                boxes = maybe_boxes
             return images
 
         def boxes_only(data, maybe_boxes=None):
             if maybe_boxes is None:
                 images, boxes = unpack_input(data)
             else:
-                images = data
                 boxes = maybe_boxes
             return boxes
 
@@ -80,7 +77,6 @@ class PyCOCOCallback(Callback):
         valid_det = ops.convert_to_numpy(y_pred["num_detections"])
 
         gt = [boxes for boxes in self.val_data.map(boxes_only)]
-        print(gt)
         gt_boxes = ops.concatenate(
             [ops.convert_to_numpy(boxes["boxes"]) for boxes in gt],
             axis=0,

--- a/keras_cv/callbacks/pycoco_callback_test.py
+++ b/keras_cv/callbacks/pycoco_callback_test.py
@@ -14,7 +14,6 @@
 
 import pytest
 import tensorflow as tf
-from tensorflow import keras
 
 import keras_cv
 from keras_cv.callbacks import PyCOCOCallback
@@ -25,12 +24,6 @@ from keras_cv.models.object_detection.__test_utils__ import (
 
 
 class PyCOCOCallbackTest(tf.test.TestCase):
-    @pytest.fixture(autouse=True)
-    def cleanup_global_session(self):
-        # Code before yield runs before the test
-        yield
-        keras.backend.clear_session()
-
     @pytest.mark.large  # Fit is slow, so mark these large.
     def test_model_fit_retinanet(self):
         model = keras_cv.models.RetinaNet(
@@ -52,8 +45,15 @@ class PyCOCOCallbackTest(tf.test.TestCase):
             bounding_box_format="xyxy", use_dictionary_box_format=True
         )
 
+        def dict_to_tuple(inputs):
+            return inputs["images"], inputs["bounding_boxes"]
+
+        train_ds = train_ds.map(dict_to_tuple)
+        val_ds = val_ds.map(dict_to_tuple)
+
         callback = PyCOCOCallback(
-            validation_data=val_ds, bounding_box_format="xyxy"
+            validation_data=val_ds,
+            bounding_box_format="xyxy",
         )
         history = model.fit(train_ds, callbacks=[callback])
 

--- a/keras_cv/layers/object_detection/non_max_suppression.py
+++ b/keras_cv/layers/object_detection/non_max_suppression.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import math
-
 import tensorflow as tf
 
 from keras_cv import bounding_box
@@ -236,7 +235,11 @@ def non_max_suppression(
     scores, boxes, sorted_indices = _sort_scores_and_boxes(scores, boxes)
 
     pad = (
-        math.ceil(max(num_boxes, max_output_size) / tile_size) * tile_size
+        math.ceil(
+            max(num_boxes, max_output_size)
+            / tile_size
+        )
+        * tile_size
         - num_boxes
     )
     boxes = ops.pad(ops.cast(boxes, "float32"), [[0, 0], [0, pad], [0, 0]])
@@ -269,10 +272,7 @@ def non_max_suppression(
     idx = num_boxes_after_padding - ops.cast(
         ops.top_k(
             ops.cast(ops.any(selected_boxes > 0, [2]), "int32")
-            * ops.cast(
-                ops.expand_dims(ops.arange(num_boxes_after_padding, 0, -1), 0),
-                "int32",
-            ),
+            * ops.cast(ops.expand_dims(ops.arange(num_boxes_after_padding, 0, -1), 0), "int32"),
             max_output_size,
         )[0],
         "int32",
@@ -519,7 +519,7 @@ def _suppression_loop_body(boxes, iou_threshold, output_size, idx, tile_size):
             [1, -1, 1, 1],
         )
         boxes = ops.tile(
-            ops.expand_dims(box_slice, [1]), [1, num_tiles, 1, 1]
+            ops.expand_dims(box_slice, 1), [1, num_tiles, 1, 1]
         ) * mask + ops.reshape(boxes, [batch_size, num_tiles, tile_size, 4]) * (
             1 - mask
         )

--- a/keras_cv/layers/object_detection/non_max_suppression.py
+++ b/keras_cv/layers/object_detection/non_max_suppression.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import math
+
 import tensorflow as tf
 
 from keras_cv import bounding_box
@@ -235,11 +236,7 @@ def non_max_suppression(
     scores, boxes, sorted_indices = _sort_scores_and_boxes(scores, boxes)
 
     pad = (
-        math.ceil(
-            max(num_boxes, max_output_size)
-            / tile_size
-        )
-        * tile_size
+        math.ceil(max(num_boxes, max_output_size) / tile_size) * tile_size
         - num_boxes
     )
     boxes = ops.pad(ops.cast(boxes, "float32"), [[0, 0], [0, pad], [0, 0]])
@@ -272,7 +269,10 @@ def non_max_suppression(
     idx = num_boxes_after_padding - ops.cast(
         ops.top_k(
             ops.cast(ops.any(selected_boxes > 0, [2]), "int32")
-            * ops.cast(ops.expand_dims(ops.arange(num_boxes_after_padding, 0, -1), 0), "int32"),
+            * ops.cast(
+                ops.expand_dims(ops.arange(num_boxes_after_padding, 0, -1), 0),
+                "int32",
+            ),
             max_output_size,
         )[0],
         "int32",

--- a/keras_cv/layers/preprocessing/aug_mix.py
+++ b/keras_cv/layers/preprocessing/aug_mix.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import layers
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
@@ -18,6 +18,7 @@ from keras import backend as keras_backend
 from keras_cv import bounding_box
 from keras_cv.backend import keras
 from keras_cv.backend import scope
+from keras_cv.backend.config import multi_backend
 from keras_cv.utils import preprocessing
 
 # In order to support both unbatched and batched inputs, the horizontal
@@ -35,8 +36,15 @@ IS_DICT = "is_dict"
 USE_TARGETS = "use_targets"
 
 
+base_class = (
+    keras.layers.preprocessing.tf_data_layer.TFDataLayer
+    if multi_backend()
+    else keras.layers.Layer
+)
+
+
 @keras.utils.register_keras_serializable(package="keras_cv")
-class BaseImageAugmentationLayer(keras.layers.preprocessing.tf_data_layer.TFDataLayer):
+class BaseImageAugmentationLayer(base_class):
     """Abstract base layer for image augmentation.
 
     This layer contains base functionalities for preprocessing layers which
@@ -121,6 +129,7 @@ class BaseImageAugmentationLayer(keras.layers.preprocessing.tf_data_layer.TFData
             seed=seed, force_generator=force_generator
         )
         super().__init__(**kwargs)
+        self._convert_input_args = False
 
     @property
     def force_output_ragged_images(self):

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
+from keras import backend as keras_backend
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
+from keras_cv.backend import scope
 from keras_cv.utils import preprocessing
 
 # In order to support both unbatched and batched inputs, the horizontal
@@ -34,7 +36,7 @@ USE_TARGETS = "use_targets"
 
 
 @keras.utils.register_keras_serializable(package="keras_cv")
-class BaseImageAugmentationLayer(keras.__internal__.layers.BaseRandomLayer):
+class BaseImageAugmentationLayer(keras.layers.Layer):
     """Abstract base layer for image augmentation.
 
     This layer contains base functionalities for preprocessing layers which
@@ -114,7 +116,11 @@ class BaseImageAugmentationLayer(keras.__internal__.layers.BaseRandomLayer):
     """
 
     def __init__(self, seed=None, **kwargs):
-        super().__init__(seed=seed, **kwargs)
+        force_generator = kwargs.pop("force_generator", False)
+        self._random_generator = keras_backend.RandomGenerator(
+            seed=seed, force_generator=force_generator
+        )
+        super().__init__(**kwargs)
 
     @property
     def force_output_ragged_images(self):
@@ -391,19 +397,23 @@ class BaseImageAugmentationLayer(keras.__internal__.layers.BaseRandomLayer):
         return None
 
     def call(self, inputs):
-        inputs = self._ensure_inputs_are_compute_dtype(inputs)
-        inputs, metadata = self._format_inputs(inputs)
-        images = inputs[IMAGES]
-        if images.shape.rank == 3:
-            return self._format_output(self._augment(inputs), metadata)
-        elif images.shape.rank == 4:
-            return self._format_output(self._batch_augment(inputs), metadata)
-        else:
-            raise ValueError(
-                "Image augmentation layers are expecting inputs to be "
-                "rank 3 (HWC) or 4D (NHWC) tensors. Got shape: "
-                f"{images.shape}"
-            )
+        with scope.TFDataScope():
+            inputs = self._ensure_inputs_are_compute_dtype(inputs)
+            inputs, metadata = self._format_inputs(inputs)
+            images = inputs[IMAGES]
+            if images.shape.rank == 3:
+                outputs = self._format_output(self._augment(inputs), metadata)
+            elif images.shape.rank == 4:
+                outputs = self._format_output(
+                    self._batch_augment(inputs), metadata
+                )
+            else:
+                raise ValueError(
+                    "Image augmentation layers are expecting inputs to be "
+                    "rank 3 (HWC) or 4D (NHWC) tensors. Got shape: "
+                    f"{images.shape}"
+                )
+            return outputs
 
     def _augment(self, inputs):
         raw_image = inputs.get(IMAGES, None)
@@ -498,7 +508,7 @@ class BaseImageAugmentationLayer(keras.__internal__.layers.BaseRandomLayer):
         if not isinstance(inputs, dict):
             raise ValueError(
                 "Expect the inputs to be image tensor or dict. Got "
-                f"inputs={inputs}"
+                f"inputs={inputs} of type {type(inputs)}"
             )
 
         if BOUNDING_BOXES in inputs:

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
@@ -36,7 +36,7 @@ USE_TARGETS = "use_targets"
 
 
 @keras.utils.register_keras_serializable(package="keras_cv")
-class BaseImageAugmentationLayer(keras.layers.Layer):
+class BaseImageAugmentationLayer(keras.layers.preprocessing.tf_data_layer.TFDataLayer):
     """Abstract base layer for image augmentation.
 
     This layer contains base functionalities for preprocessing layers which

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer_test.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer_test.py
@@ -12,13 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import numpy as np
-import pytest
 import tensorflow as tf
 
-from keras_cv import backend
 from keras_cv import bounding_box
-from keras_cv.backend import keras
-from keras_cv.backend.config import multi_backend
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
@@ -130,14 +126,10 @@ class BaseImageAugmentationLayerTest(tf.test.TestCase):
     def test_augment_leaves_extra_dict_entries_unmodified(self):
         add_layer = RandomAddLayer(fixed_value=0.5)
         images = np.random.random(size=(8, 8, 3)).astype("float32")
-        filenames = tf.constant("/path/to/first.jpg")
-        inputs = {"images": images, "filenames": filenames}
+        image_timestamp = tf.constant(123123123)
+        inputs = {"images": images, "image_timestamp": image_timestamp}
         _ = add_layer(inputs)
 
-    @pytest.mark.skipif(
-        backend.supports_ragged() is False,
-        reason="Only TensorFlow supports raggeds",
-    )
     def test_augment_ragged_images(self):
         images = tf.ragged.stack(
             [

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer_test.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer_test.py
@@ -232,10 +232,6 @@ class BaseImageAugmentationLayerTest(tf.test.TestCase):
             segmentation_mask_diff[0], segmentation_mask_diff[1]
         )
 
-    @pytest.mark.skipif(
-        multi_backend() and keras.backend.config.backend() != "tensorflow",
-        reason="Only TF supports in-graph preprocessing layers",
-    )
     def test_augment_all_data_in_tf_function(self):
         add_layer = RandomAddLayer()
         images = np.random.random(size=(2, 8, 8, 3)).astype("float32")

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/equalization.py
+++ b/keras_cv/layers/preprocessing/equalization.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/equalization_test.py
+++ b/keras_cv/layers/preprocessing/equalization_test.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
+from keras_cv.backend import keras
+from keras_cv.backend.config import multi_backend
 from keras_cv.layers.preprocessing.equalization import Equalization
 
 
@@ -28,6 +30,10 @@ class EqualizationTest(tf.test.TestCase, parameterized.TestCase):
         self.assertEqual(xs.shape, [2, 512, 512, 3])
         self.assertAllEqual(xs, 255 * tf.ones((2, 512, 512, 3)))
 
+    @pytest.mark.skipif(
+        multi_backend() and keras.backend.config.backend() != "tensorflow",
+        reason="Only TF supports in-graph preprocessing layers",
+    )
     def test_return_shapes_inside_model(self):
         layer = Equalization(value_range=(0, 255))
         inp = keras.layers.Input(shape=[512, 512, 5])

--- a/keras_cv/layers/preprocessing/fourier_mix.py
+++ b/keras_cv/layers/preprocessing/fourier_mix.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/grayscale.py
+++ b/keras_cv/layers/preprocessing/grayscale.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/grid_mask.py
+++ b/keras_cv/layers/preprocessing/grid_mask.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import layers
 
 from keras_cv import core
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
@@ -118,7 +117,7 @@ class GridMask(BaseImageAugmentationLayer):
         self.fill_mode = fill_mode
         self.fill_value = fill_value
         self.rotation_factor = rotation_factor
-        self.random_rotate = layers.RandomRotation(
+        self.random_rotate = keras.layers.RandomRotation(
             factor=rotation_factor,
             fill_mode="constant",
             fill_value=0.0,

--- a/keras_cv/layers/preprocessing/jittered_resize.py
+++ b/keras_cv/layers/preprocessing/jittered_resize.py
@@ -17,9 +17,9 @@
 # https://github.com/tensorflow/models/blob/master/official/vision/ops/preprocess_ops.py
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/mosaic.py
+++ b/keras_cv/layers/preprocessing/mosaic.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     BATCHED,
 )

--- a/keras_cv/layers/preprocessing/mosaic_test.py
+++ b/keras_cv/layers/preprocessing/mosaic_test.py
@@ -96,16 +96,6 @@ class MosaicTest(tf.test.TestCase):
         ):
             _ = layer(inputs)
 
-    def test_int_labels(self):
-        xs = tf.ones((2, 512, 512, 3))
-        ys = tf.one_hot(tf.constant([1, 0]), 2, dtype=tf.int32)
-        inputs = {"images": xs, "labels": ys}
-        layer = Mosaic()
-        with self.assertRaisesRegexp(
-            ValueError, "Mosaic received labels with type"
-        ):
-            _ = layer(inputs)
-
     def test_image_input(self):
         xs = tf.ones((2, 512, 512, 3))
         layer = Mosaic()

--- a/keras_cv/layers/preprocessing/posterization.py
+++ b/keras_cv/layers/preprocessing/posterization.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/ragged_image_test.py
+++ b/keras_cv/layers/preprocessing/ragged_image_test.py
@@ -11,9 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 
+from keras_cv import backend
 from keras_cv import layers
 
 CONSISTENT_OUTPUT_TEST_CONFIGURATIONS = [
@@ -136,6 +138,10 @@ RAGGED_OUTPUT_TEST_CONFIGURATIONS = [
 ]
 
 
+@pytest.mark.skipif(
+    backend.supports_ragged() is False,
+    reason="Only TensorFlow supports raggeds",
+)
 class RaggedImageTest(tf.test.TestCase, parameterized.TestCase):
     @parameterized.named_parameters(*CONSISTENT_OUTPUT_TEST_CONFIGURATIONS)
     def test_preserves_ragged_status(self, layer_cls, init_args):

--- a/keras_cv/layers/preprocessing/ragged_image_test.py
+++ b/keras_cv/layers/preprocessing/ragged_image_test.py
@@ -11,11 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 
-from keras_cv import backend
 from keras_cv import layers
 
 CONSISTENT_OUTPUT_TEST_CONFIGURATIONS = [
@@ -138,10 +136,6 @@ RAGGED_OUTPUT_TEST_CONFIGURATIONS = [
 ]
 
 
-@pytest.mark.skipif(
-    backend.supports_ragged() is False,
-    reason="Only TensorFlow supports raggeds",
-)
 class RaggedImageTest(tf.test.TestCase, parameterized.TestCase):
     @parameterized.named_parameters(*CONSISTENT_OUTPUT_TEST_CONFIGURATIONS)
     def test_preserves_ragged_status(self, layer_cls, init_args):

--- a/keras_cv/layers/preprocessing/rand_augment.py
+++ b/keras_cv/layers/preprocessing/rand_augment.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tensorflow import keras
-
 from keras_cv import core
+from keras_cv.backend import keras
 from keras_cv.layers import preprocessing as cv_preprocessing
 from keras_cv.layers.preprocessing.random_augmentation_pipeline import (
     RandomAugmentationPipeline,

--- a/keras_cv/layers/preprocessing/random_apply.py
+++ b/keras_cv/layers/preprocessing/random_apply.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tensorflow import keras
-
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_apply_test.py
+++ b/keras_cv/layers/preprocessing/random_apply_test.py
@@ -14,9 +14,9 @@
 
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
 from keras_cv import layers
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
+++ b/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers import preprocessing
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,

--- a/keras_cv/layers/preprocessing/random_augmentation_pipeline_test.py
+++ b/keras_cv/layers/preprocessing/random_augmentation_pipeline_test.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
 from keras_cv import layers
+from keras_cv.backend import keras
+from keras_cv.backend.config import multi_backend
 
 
 class AddOneToInputs(keras.layers.Layer):
@@ -54,6 +56,10 @@ class RandomAugmentationPipelineTest(tf.test.TestCase, parameterized.TestCase):
 
         self.assertAllClose(xs, os)
 
+    @pytest.mark.skipif(
+        multi_backend() and keras.backend.config.backend() != "tensorflow",
+        reason="Only TF supports in-graph preprocessing layers",
+    )
     def test_calls_layers_augmentations_in_graph(self):
         layer = AddOneToInputs()
         pipeline = layers.RandomAugmentationPipeline(

--- a/keras_cv/layers/preprocessing/random_brightness.py
+++ b/keras_cv/layers/preprocessing/random_brightness.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_channel_shift.py
+++ b/keras_cv/layers/preprocessing/random_channel_shift.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_choice.py
+++ b/keras_cv/layers/preprocessing/random_choice.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_choice_test.py
+++ b/keras_cv/layers/preprocessing/random_choice_test.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
 from keras_cv import layers
+from keras_cv.backend import keras
+from keras_cv.backend.config import multi_backend
 
 
 class AddOneToInputs(keras.layers.Layer):
@@ -40,6 +42,10 @@ class RandomAugmentationPipelineTest(tf.test.TestCase, parameterized.TestCase):
 
         self.assertAllClose(xs + 1, os)
 
+    @pytest.mark.skipif(
+        multi_backend() and keras.backend.config.backend() != "tensorflow",
+        reason="Only TF supports in-graph preprocessing layers",
+    )
     def test_calls_layer_augmentation_in_graph(self):
         layer = AddOneToInputs()
         pipeline = layers.RandomChoice(layers=[layer])

--- a/keras_cv/layers/preprocessing/random_color_degeneration.py
+++ b/keras_cv/layers/preprocessing/random_color_degeneration.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_color_jitter.py
+++ b/keras_cv/layers/preprocessing/random_color_jitter.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tensorflow import keras
-
+from keras_cv.backend import keras
 from keras_cv.layers import preprocessing
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,

--- a/keras_cv/layers/preprocessing/random_contrast.py
+++ b/keras_cv/layers/preprocessing/random_contrast.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_crop.py
+++ b/keras_cv/layers/preprocessing/random_crop.py
@@ -14,9 +14,9 @@
 
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_crop_and_resize.py
+++ b/keras_cv/layers/preprocessing/random_crop_and_resize.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import bounding_box
 from keras_cv import core
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_crop_test.py
+++ b/keras_cv/layers/preprocessing/random_crop_test.py
@@ -17,8 +17,8 @@ import unittest
 import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.random_crop import RandomCrop
 
 

--- a/keras_cv/layers/preprocessing/random_cutout.py
+++ b/keras_cv/layers/preprocessing/random_cutout.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_flip.py
+++ b/keras_cv/layers/preprocessing/random_flip.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_gaussian_blur.py
+++ b/keras_cv/layers/preprocessing/random_gaussian_blur.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_hue.py
+++ b/keras_cv/layers/preprocessing/random_hue.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_jpeg_quality.py
+++ b/keras_cv/layers/preprocessing/random_jpeg_quality.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_rotation.py
+++ b/keras_cv/layers/preprocessing/random_rotation.py
@@ -14,9 +14,9 @@
 
 import numpy as np
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_rotation.py
+++ b/keras_cv/layers/preprocessing/random_rotation.py
@@ -231,7 +231,7 @@ class RandomRotation(VectorizedBaseImageAugmentationLayer):
         # mask sparse again using tf.argmax.
         if self.segmentation_classes:
             one_hot_mask = tf.one_hot(
-                tf.squeeze(segmentation_masks, axis=-1),
+                tf.squeeze(tf.cast(segmentation_masks, tf.int32), axis=-1),
                 self.segmentation_classes,
             )
             rotated_one_hot_mask = self._rotate_images(

--- a/keras_cv/layers/preprocessing/random_saturation.py
+++ b/keras_cv/layers/preprocessing/random_saturation.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_saturation_test.py
+++ b/keras_cv/layers/preprocessing/random_saturation_test.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import core
+from keras_cv.backend import keras
 from keras_cv.layers import preprocessing
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,

--- a/keras_cv/layers/preprocessing/random_sharpness.py
+++ b/keras_cv/layers/preprocessing/random_sharpness.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_shear.py
+++ b/keras_cv/layers/preprocessing/random_shear.py
@@ -15,10 +15,10 @@
 import warnings
 
 import tensorflow as tf
-from tensorflow import keras
 
 import keras_cv
 from keras_cv import bounding_box
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_translation.py
+++ b/keras_cv/layers/preprocessing/random_translation.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 import keras_cv
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_zoom.py
+++ b/keras_cv/layers/preprocessing/random_zoom.py
@@ -15,8 +15,8 @@
 
 import tensorflow as tf
 from keras import backend
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/repeated_augmentation.py
+++ b/keras_cv/layers/preprocessing/repeated_augmentation.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/rescaling.py
+++ b/keras_cv/layers/preprocessing/rescaling.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/resizing.py
+++ b/keras_cv/layers/preprocessing/resizing.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 import keras_cv.utils
 from keras_cv import bounding_box
+from keras_cv.backend import ops
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
@@ -309,7 +309,7 @@ class Resizing(BaseImageAugmentationLayer):
         def resize_with_crop_to_aspect(x, interpolation_method):
             if isinstance(x, tf.RaggedTensor):
                 x = x.to_tensor()
-            return keras.preprocessing.image.smart_resize(
+            return ops.smart_resize(
                 x,
                 size=size,
                 interpolation=interpolation_method,

--- a/keras_cv/layers/preprocessing/resizing_test.py
+++ b/keras_cv/layers/preprocessing/resizing_test.py
@@ -12,10 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import numpy as np
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 
+from keras_cv import backend
 from keras_cv import layers as cv_layers
+from keras_cv.backend import keras
+from keras_cv.backend.config import multi_backend
 
 
 class ResizingTest(tf.test.TestCase, parameterized.TestCase):
@@ -149,6 +153,10 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
         ("crop_to_aspect_ratio_false", False),
         ("crop_to_aspect_ratio_true", True),
     )
+    @pytest.mark.skipif(
+        backend.supports_ragged() is False,
+        reason="Only TensorFlow supports raggeds",
+    )
     def test_ragged_image(self, crop_to_aspect_ratio):
         inputs = tf.ragged.constant(
             [
@@ -191,6 +199,10 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
         ("batch_pad_to_aspect_ratio", False, True, True),
         ("single_sample_pad_to_aspect_ratio", False, True, False),
     )
+    @pytest.mark.skipif(
+        multi_backend() and keras.backend.config.backend() != "tensorflow",
+        reason="Only TF supports in-graph preprocessing layers",
+    )
     def test_static_shape_inference(
         self, crop_to_aspect_ratio, pad_to_aspect_ratio, batch
     ):
@@ -226,6 +238,10 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
         img_data = np.random.random(size=input_shape).astype("float32")
         tf_function(img_data)
 
+    @pytest.mark.skipif(
+        backend.supports_ragged() is False,
+        reason="Only TensorFlow supports raggeds",
+    )
     def test_pad_to_size_with_bounding_boxes_ragged_images(self):
         images = tf.ragged.constant(
             [
@@ -264,6 +280,10 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
             outputs["images"].shape.as_list(),
         )
 
+    @pytest.mark.skipif(
+        backend.supports_ragged() is False,
+        reason="Only TensorFlow supports raggeds",
+    )
     def test_pad_to_size_with_bounding_boxes_ragged_images_upsample(self):
         images = tf.ragged.constant(
             [

--- a/keras_cv/layers/preprocessing/solarization.py
+++ b/keras_cv/layers/preprocessing/solarization.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
+from keras import backend as keras_backend
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
+from keras_cv.backend import scope
 from keras_cv.utils import preprocessing
 
 H_AXIS = -3
@@ -34,9 +36,7 @@ USE_TARGETS = "use_targets"
 
 
 @keras.utils.register_keras_serializable(package="keras_cv")
-class VectorizedBaseImageAugmentationLayer(
-    keras.__internal__.layers.BaseRandomLayer
-):
+class VectorizedBaseImageAugmentationLayer(keras.layers.Layer):
     """Abstract base layer for vectorized image augmentation.
 
     This layer contains base functionalities for preprocessing layers which
@@ -95,7 +95,11 @@ class VectorizedBaseImageAugmentationLayer(
     """
 
     def __init__(self, seed=None, **kwargs):
-        super().__init__(seed=seed, **kwargs)
+        force_generator = kwargs.pop("force_generator", False)
+        self._random_generator = keras_backend.RandomGenerator(
+            seed=seed, force_generator=force_generator
+        )
+        super().__init__(**kwargs)
 
     @property
     def force_output_dense_images(self):
@@ -402,17 +406,21 @@ class VectorizedBaseImageAugmentationLayer(
         return result
 
     def call(self, inputs):
-        inputs = self._ensure_inputs_are_compute_dtype(inputs)
-        inputs, metadata = self._format_inputs(inputs)
-        images = inputs[IMAGES]
-        if images.shape.rank == 3 or images.shape.rank == 4:
-            return self._format_output(self._batch_augment(inputs), metadata)
-        else:
-            raise ValueError(
-                "Image augmentation layers are expecting inputs to be "
-                "rank 3 (HWC) or 4D (NHWC) tensors. Got shape: "
-                f"{images.shape}"
-            )
+        with scope.TFDataScope():
+            inputs = self._ensure_inputs_are_compute_dtype(inputs)
+            inputs, metadata = self._format_inputs(inputs)
+            images = inputs[IMAGES]
+            if images.shape.rank == 3 or images.shape.rank == 4:
+                outputs = self._format_output(
+                    self._batch_augment(inputs), metadata
+                )
+            else:
+                raise ValueError(
+                    "Image augmentation layers are expecting inputs to be "
+                    "rank 3 (HWC) or 4D (NHWC) tensors. Got shape: "
+                    f"{images.shape}"
+                )
+            return outputs
 
     def _format_inputs(self, inputs):
         metadata = {IS_DICT: True, USE_TARGETS: False}

--- a/keras_cv/layers/preprocessing/with_mixed_precision_test.py
+++ b/keras_cv/layers/preprocessing/with_mixed_precision_test.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
 from keras_cv import layers
+from keras_cv.backend import keras
+from keras_cv.backend.config import multi_backend
 
 TEST_CONFIGURATIONS = [
     ("AutoContrast", layers.AutoContrast, {"value_range": (0, 255)}),
@@ -145,6 +147,10 @@ NO_CPU_FP16_KERNEL_LAYERS = [
 ]
 
 
+@pytest.mark.skipif(
+    multi_backend(),
+    reason="Multi-backend Keras doesn't yet support mixed precision",
+)
 class WithMixedPrecisionTest(tf.test.TestCase, parameterized.TestCase):
     @parameterized.named_parameters(*TEST_CONFIGURATIONS)
     def test_can_run_in_mixed_precision(self, layer_cls, init_args):

--- a/keras_cv/layers/preprocessing/with_segmentation_masks_test.py
+++ b/keras_cv/layers/preprocessing/with_segmentation_masks_test.py
@@ -132,6 +132,4 @@ class WithSegmentationMasksTest(tf.test.TestCase, parameterized.TestCase):
         # This currently asserts that all layers are no-ops.
         # When preprocessing layers are updated to mutate segmentation masks,
         # this condition should only be asserted for no-op layers.
-        self.assertAllClose(
-            inputs["segmentation_masks"], outputs["segmentation_masks"]
-        )
+        self.assertAllClose(segmentation_mask, outputs["segmentation_masks"])

--- a/keras_cv/metrics/coco/pycoco_wrapper.py
+++ b/keras_cv/metrics/coco/pycoco_wrapper.py
@@ -14,7 +14,8 @@
 import copy
 
 import numpy as np
-import tensorflow as tf
+
+from keras_cv.backend import keras
 
 try:
     from pycocotools.coco import COCO
@@ -193,23 +194,16 @@ def _convert_groundtruths_to_coco_dataset(groundtruths, label_map=None):
     return gt_dataset
 
 
-def _convert_to_numpy(groundtruths, predictions):
+def _concat_numpy(groundtruths, predictions):
     """Converts tensors to numpy arrays."""
-    labels = tf.nest.map_structure(lambda x: x.numpy(), groundtruths)
     numpy_groundtruths = {}
-    for key, val in labels.items():
+    for key, val in groundtruths.items():
         if isinstance(val, tuple):
             val = np.concatenate(val)
         numpy_groundtruths[key] = val
 
-    def _to_numpy(x):
-        if isinstance(x, np.ndarray):
-            return x
-        return x.numpy()
-
-    outputs = tf.nest.map_structure(lambda x: _to_numpy(x), predictions)
     numpy_predictions = {}
-    for key, val in outputs.items():
+    for key, val in predictions.items():
         if isinstance(val, tuple):
             val = np.concatenate(val)
         numpy_predictions[key] = val
@@ -220,7 +214,7 @@ def _convert_to_numpy(groundtruths, predictions):
 def compute_pycoco_metrics(groundtruths, predictions):
     assert_pycocotools_installed("compute_pycoco_metrics")
 
-    groundtruths, predictions = _convert_to_numpy(groundtruths, predictions)
+    groundtruths, predictions = _concat_numpy(groundtruths, predictions)
 
     gt_dataset = _convert_groundtruths_to_coco_dataset(groundtruths)
     coco_gt = PyCOCOWrapper(gt_dataset=gt_dataset)

--- a/keras_cv/metrics/coco/pycoco_wrapper.py
+++ b/keras_cv/metrics/coco/pycoco_wrapper.py
@@ -15,8 +15,6 @@ import copy
 
 import numpy as np
 
-from keras_cv.backend import keras
-
 try:
     from pycocotools.coco import COCO
     from pycocotools.cocoeval import COCOeval

--- a/keras_cv/metrics/object_detection/box_coco_metrics.py
+++ b/keras_cv/metrics/object_detection/box_coco_metrics.py
@@ -15,11 +15,13 @@ import os
 import sys
 import types
 
+import numpy as np
 import tensorflow as tf
 import tensorflow.keras as keras
 
 import keras_cv
 from keras_cv import bounding_box
+from keras_cv.backend import ops
 
 
 class HidePrints:
@@ -260,6 +262,9 @@ class BoxCOCOMetrics(keras.metrics.Metric):
 
 
 def compute_pycocotools_metric(y_true, y_pred, bounding_box_format):
+    y_true = bounding_box.to_dense(y_true)
+    y_pred = bounding_box.to_dense(y_pred)
+
     box_pred = y_pred["boxes"]
     cls_pred = y_pred["classes"]
     confidence_pred = y_pred["confidence"]
@@ -276,26 +281,24 @@ def compute_pycocotools_metric(y_true, y_pred, bounding_box_format):
 
     total_images = gt_boxes.shape[0]
 
-    source_ids = tf.strings.as_string(
-        tf.linspace(1, total_images, total_images), precision=0
-    )
+    source_ids = np.char.mod("%d", np.linspace(1, total_images, total_images))
 
     ground_truth = {}
     ground_truth["source_id"] = [source_ids]
 
     ground_truth["num_detections"] = [
-        tf.math.reduce_sum(tf.cast(y_true["classes"] != -1, tf.int32), axis=-1)
+        ops.sum(ops.cast(y_true["classes"] >= 0, "int32"), axis=-1)
     ]
-    ground_truth["boxes"] = [gt_boxes]
-    ground_truth["classes"] = [gt_classes]
+    ground_truth["boxes"] = [ops.convert_to_numpy(gt_boxes)]
+    ground_truth["classes"] = [ops.convert_to_numpy(gt_classes)]
 
     predictions = {}
     predictions["source_id"] = [source_ids]
-    predictions["detection_boxes"] = [box_pred]
-    predictions["detection_classes"] = [cls_pred]
-    predictions["detection_scores"] = [confidence_pred]
+    predictions["detection_boxes"] = [ops.convert_to_numpy(box_pred)]
+    predictions["detection_classes"] = [ops.convert_to_numpy(cls_pred)]
+    predictions["detection_scores"] = [ops.convert_to_numpy(confidence_pred)]
     predictions["num_detections"] = [
-        tf.math.reduce_sum(tf.cast(y_pred["classes"] != -1, tf.int32), axis=-1)
+        ops.sum(ops.cast(confidence_pred > 0, "int32"), axis=-1)
     ]
 
     return keras_cv.metrics.coco.compute_pycoco_metrics(

--- a/keras_cv/models/object_detection/retinanet/retinanet_label_encoder_test.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet_label_encoder_test.py
@@ -16,9 +16,9 @@ import numpy as np
 import pytest
 import tensorflow as tf
 
+from keras_cv import backend
 from keras_cv import layers as cv_layers
 from keras_cv.backend import ops
-from keras_cv.backend import supports_ragged
 from keras_cv.models.object_detection.retinanet import RetinaNetLabelEncoder
 
 
@@ -86,7 +86,7 @@ class RetinaNetLabelEncoderTest(tf.test.TestCase):
         self.assertFalse(ops.any(ops.isnan(class_targets)))
 
     @pytest.mark.skipif(
-        supports_ragged() is False,
+        backend.supports_ragged() is False,
         reason="Only TensorFlow supports raggeds",
     )
     def test_ragged_encoding(self):


### PR DESCRIPTION
This currently makes these layers all-TF all-the time.

If we want to make them only use tf when in a TF graph, we can update the TFDataScope to only enter the scope if we're in-graph (see keras_core.layers.preprocessing.TFDataLayer for an example)